### PR TITLE
fix(docs): point Contributing/License links at GitHub, not relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Other projects worth knowing about while exploring the Jolt ecosystem.
 
 ## Contributing
 
-Contributions welcome. Read the [contribution guidelines](CONTRIBUTING.md) first, then open a pull request.
+Contributions welcome. Read the [contribution guidelines](https://github.com/jlt-commons/awesome-jolt/blob/main/CONTRIBUTING.md) first, then open a pull request.
 
 ## License
 
@@ -247,6 +247,6 @@ Contributions welcome. Read the [contribution guidelines](CONTRIBUTING.md) first
 
 To the extent possible under law, the contributors to this list have waived
 all copyright and related or neighboring rights to it, under the
-[CC0 1.0 Universal](LICENSE) public domain dedication. This list only points
+[CC0 1.0 Universal](https://github.com/jlt-commons/awesome-jolt/blob/main/LICENSE) public domain dedication. This list only points
 to and describes other people's work; each linked project keeps its own
 license, so check a repository before depending on it.


### PR DESCRIPTION
Fixes the 404 reported on the live site: the "contribution guidelines" link resolved to `https://jlt-commons.github.io/awesome-jolt/guide/CONTRIBUTING.html`, which doesn't exist.

## Root cause

The docs site's homepage is README.md, published through `docs/guide/index.md` (a symlink required because the docs-engine hard-requires that directory to exist). Rendering through that guide-index path runs every relative `.html` link through an extra `guide/`-prefix rewrite meant for links between guide pages. `CONTRIBUTING.md` and `LICENSE` aren't guide pages — the engine never publishes them anywhere — so the rewrite mangled them into dead links:

- `CONTRIBUTING.md` -> `guide/CONTRIBUTING.html` (the reported 404)
- `LICENSE` -> a same-directory `LICENSE` link, also broken, just not yet reported

Both links work fine when viewing README.md directly on GitHub, which is why the repo view looked correct.

## Fix

Point both links at their GitHub blob URLs instead of relative paths. Absolute `https://` links are explicitly left untouched by both link-rewrite passes in docs-engine, so this sidesteps the bug entirely and renders identically on GitHub and on the published site.

## Verification

`bb site:build` + `docs/check-site.sh` pass, and the rendered `_site/index.html` confirms both hrefs are now the absolute GitHub URLs, untouched by the rewrite.
