### PR TITLE
feat(readme): add talk, an XMPP server written in Jolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ or jump straight to [Getting Started](https://jolt-lang.net/docs/getting-started
 - [Getting Started](#getting-started)
 - [Official Libraries](#official-libraries)
 - [Community Projects](#community-projects)
+- [Applications](#applications)
 - [JVM and Clojure Libraries That Run on Jolt](#jvm-and-clojure-libraries-that-run-on-jolt)
 - [Tooling, Testing and Examples](#tooling-testing-and-examples)
 - [Documentation and Guides](#documentation-and-guides)
@@ -118,6 +119,12 @@ Projects maintained at [jlt-commons](https://jlt-commons.github.io), a community
 ### Concurrency
 
 - [ebb](https://github.com/jlt-commons/ebb) - A port of [missionary](https://github.com/leonoel/missionary): composable tasks and flows with real cancellation and glitch-free dataflow, running on Chez fibers.
+
+## Applications
+
+Independently maintained software built with Jolt, hosted and maintained outside jlt-commons and jolt-lang.
+
+- [talk](https://gitlab.com/nandithebull/talk) - An XMPP server speaking RFC 6120 (core) and RFC 6121 (IM and presence): SASL, SCRAM-SHA-256, resource binding, rosters, presence, offline delivery, and a Prosody-inspired module architecture.
 
 ## JVM and Clojure Libraries That Run on Jolt
 

--- a/docs/templates/generic-home.html
+++ b/docs/templates/generic-home.html
@@ -15,8 +15,9 @@
    this README's real subject-matter sections (the housekeeping ones —
    Contributing, License, Community and Support — aren't topics, so they
    aren't tags). Sizes come from a plain item-count tally per section,
-   done by hand against the README on 2026-09-06; re-tally if the list
-   grows enough to shift a tier. Uses only the engine's own theme tokens,
+   done by hand against the README, last re-tallied 2026-09-07 to add the
+   Applications section; re-tally again if the list grows enough to shift
+   a tier. Uses only the engine's own theme tokens,
    so it follows light/dark exactly like the rest of the page. #}
 {% block head %}
 <style>
@@ -65,6 +66,7 @@
       <a class="tag-1" href="#getting-started">Getting Started<span class="count">3</span></a>
       <a class="tag-3" href="#official-libraries">Official Libraries<span class="count">25</span></a>
       <a class="tag-2" href="#community-projects">Community Projects<span class="count">8</span></a>
+      <a class="tag-1" href="#applications">Applications<span class="count">1</span></a>
       <a class="tag-4" href="#jvm-and-clojure-libraries-that-run-on-jolt">JVM and Clojure Libraries That Run on Jolt<span class="count">44</span></a>
       <a class="tag-1" href="#tooling-testing-and-examples">Tooling, Testing and Examples<span class="count">3</span></a>
       <a class="tag-3" href="#documentation-and-guides">Documentation and Guides<span class="count">17</span></a>


### PR DESCRIPTION
Adds [talk](https://gitlab.com/nandithebull/talk), an XMPP server written in Jolt: RFC 6120/6121, SASL, SCRAM-SHA-256, resource binding, rosters, presence, and offline delivery, in a Prosody-inspired module architecture. It's original Jolt code, not a port of an existing JVM library.

## Why a new section

None of the existing sections fit cleanly:

- **Community Projects** is explicitly scoped to jlt-commons-hosted work (its own intro paragraph says so) — `talk` lives on GitLab under an unrelated personal account.
- **JVM and Clojure Libraries That Run on Jolt** is for ports of existing JVM libraries — this is original work.
- **Related Projects** is for ecosystem-adjacent communities (jank, clj-commons, Clojure) rather than software built with Jolt.

Added a new **Applications** section for independently maintained software built with Jolt, hosted outside jlt-commons/jolt-lang. Updated the Contents ToC to match, and re-tallied the homepage's hand-built tag cloud (`docs/templates/generic-home.html`) to include it.

## Verification

`bb site:build` + `docs/check-site.sh` pass. The new section's heading id (`#applications`) matches both the ToC and tag-cloud anchors, and the `talk` link renders as an untouched absolute URL — same class of link-rewrite concern as #2, avoided by using an absolute URL from the start.
