### PR TITLE
feat(readme): add frq and jolt-native, two more nandithebull projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Projects maintained at [jlt-commons](https://jlt-commons.github.io), a community
 Independently maintained software built with Jolt, hosted and maintained outside jlt-commons and jolt-lang.
 
 - [talk](https://gitlab.com/nandithebull/talk) - An XMPP server speaking RFC 6120 (core) and RFC 6121 (IM and presence): SASL, SCRAM-SHA-256, resource binding, rosters, presence, offline delivery, and a Prosody-inspired module architecture.
+- [frq](https://gitlab.com/nandithebull/frq) - A [freeq](https://github.com/codegod100/freeq) IRC client, its screens built as [glimmer](https://github.com/jolt-lang/glimmer) components over Vidya/egui, ported from a Rust client of the same shape. Runs unchanged on desktop, in a terminal, and on Android.
+- [jolt-native](https://gitlab.com/nandithebull/jolt-native) - Native capabilities for Jolt, one shared object per capability: a retained-tree UI ABI over egui (also paintable to a terminal) and freeq's AV media plane over MoQ. What frq links against.
 
 ## JVM and Clojure Libraries That Run on Jolt
 

--- a/docs/templates/generic-home.html
+++ b/docs/templates/generic-home.html
@@ -15,9 +15,10 @@
    this README's real subject-matter sections (the housekeeping ones —
    Contributing, License, Community and Support — aren't topics, so they
    aren't tags). Sizes come from a plain item-count tally per section,
-   done by hand against the README, last re-tallied 2026-09-07 to add the
-   Applications section; re-tally again if the list grows enough to shift
-   a tier. Uses only the engine's own theme tokens,
+   done by hand against the README, last re-tallied 2026-09-07 (added the
+   Applications section, then two more entries under it same day);
+   re-tally again if the list grows enough to shift a tier. Uses only the
+   engine's own theme tokens,
    so it follows light/dark exactly like the rest of the page. #}
 {% block head %}
 <style>
@@ -66,7 +67,7 @@
       <a class="tag-1" href="#getting-started">Getting Started<span class="count">3</span></a>
       <a class="tag-3" href="#official-libraries">Official Libraries<span class="count">25</span></a>
       <a class="tag-2" href="#community-projects">Community Projects<span class="count">8</span></a>
-      <a class="tag-1" href="#applications">Applications<span class="count">1</span></a>
+      <a class="tag-1" href="#applications">Applications<span class="count">3</span></a>
       <a class="tag-4" href="#jvm-and-clojure-libraries-that-run-on-jolt">JVM and Clojure Libraries That Run on Jolt<span class="count">44</span></a>
       <a class="tag-1" href="#tooling-testing-and-examples">Tooling, Testing and Examples<span class="count">3</span></a>
       <a class="tag-3" href="#documentation-and-guides">Documentation and Guides<span class="count">17</span></a>


### PR DESCRIPTION
Adds two more projects from the same author as [talk](https://gitlab.com/nandithebull/talk) (#3), into the same Applications section:

- **[frq](https://gitlab.com/nandithebull/frq)** - a [freeq](https://github.com/codegod100/freeq) IRC client, its screens built as glimmer components over Vidya/egui, ported from a Rust client of the same shape. Runs unchanged on desktop, in a terminal, and on Android.
- **[jolt-native](https://gitlab.com/nandithebull/jolt-native)** - native capabilities for Jolt, one shared object per capability: a retained-tree UI ABI over egui (also paintable to a terminal) and freeq's AV media plane over MoQ. What frq links against.

## One judgment call worth flagging

`jolt-native` is mostly Rust with a single Jolt-side piece (`jolt/glimmer-vidya`), so it stretches "Applications" a bit if read strictly as end-user apps. Placed it there anyway rather than opening a fourth category for one entry — it's independently-hosted software built for Jolt, same as the other two, and it's a direct dependency of `frq`. Happy to split it out if that reads wrong on review.

## Verification

`bb site:build` + `docs/check-site.sh` pass. All three nandithebull links (talk, frq, jolt-native) confirmed as untouched absolute URLs in the rendered `_site/index.html`, and the Applications tag-cloud count is re-tallied to 3 (still the smallest tier, matching Getting Started and Related Projects at the same count).
