### PR TITLE
ci: pin docs-engine to v0.3.0 for the default Contributing page

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,6 +29,11 @@ jobs:
     uses: jlt-commons/ci-builds/.github/workflows/site.yml@main
     with:
       base-path: /awesome-jolt
+      # v0.3.0 adds the default Contributing page to every project's guide
+      # (docs-engine README, "The default Contributing page"). Pinned here
+      # instead of riding the shared workflow's own default so this
+      # project's build stays reproducible when that default moves again.
+      docs-engine-ref: v0.3.0
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
docs-engine v0.3.0 (jlt-commons/docs-engine#2) adds an automatic Contributing page to every project's generated guide. It's purely additive, needs no config, and any project can still override it with its own `docs/guide/contributing.md`.

The shared `jlt-commons/ci-builds` site workflow takes a `docs-engine-ref` input, but it still defaults to the older v0.2.0. This PR pins awesome-jolt's site.yml to v0.3.0 explicitly, both to pick up the new page and so the build stays reproducible the next time that shared default moves.

Same change already landed in jlt-commons/raylib-android#8.